### PR TITLE
Make both pages fully responsive down to 360px

### DIFF
--- a/src/app/components/InstallCommands.tsx
+++ b/src/app/components/InstallCommands.tsx
@@ -40,7 +40,7 @@ function CommandRow({ command }: { command: string }) {
   };
 
   return (
-    <div className="flex items-center gap-12 p-3 md:p-4 bg-card">
+    <div className="flex items-center gap-3 md:gap-12 p-3 md:p-4 bg-card">
       <code className="flex-1 font-mono text-xs md:text-sm text-foreground overflow-x-auto whitespace-nowrap no-scrollbar select-all">
         {command}
       </code>
@@ -71,20 +71,21 @@ export function InstallCommands({ name }: { name: string }) {
       <Filters.Displacement
         scale={1.3}
         frequency={0.05}
-        className="flex items-center justify-center"
+        containerClassName="w-full"
+        className="w-full flex items-center justify-center"
       >
         <Tabs
           defaultValue="pnpm"
           tabsPlacement="top"
           tabHeight="45px"
-          className="w-fit"
+          className="w-full md:max-w-1/2"
         >
-          <TabsList>
+          <TabsList className="w-full">
             {PACKAGE_MANAGERS.map((pm) => (
               <TabsTrigger
                 key={pm}
                 value={pm}
-                className="font-[Bangers] tracking-wider uppercase text-xl"
+                className="font-[Bangers] tracking-wider uppercase text-base sm:text-xl"
               >
                 {pm}
               </TabsTrigger>

--- a/src/app/components/demos.tsx
+++ b/src/app/components/demos.tsx
@@ -467,7 +467,7 @@ function CloudDemo() {
           flatteryFactor={flattery[0]}
           huggingStyle="elliptical"
         >
-          <div className="bg-accent text-card-foreground size-40 p-14 flex items-center justify-center text-center font-bold text-xl min-w-[220px]">
+          <div className="bg-accent text-card-foreground size-32 p-8 min-w-[180px] text-base sm:size-40 sm:p-14 sm:min-w-[220px] sm:text-xl flex items-center justify-center text-center font-bold">
             I&apos;m floating on a cloud!
           </div>
         </CloudWrapper>
@@ -512,13 +512,13 @@ function DisplacementDemo() {
 
   return (
     <div className="flex flex-col gap-6 w-full">
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="flex flex-col gap-2">
           <span className="font-[Bangers] text-lg tracking-wide text-center">
             Original
           </span>
           <div className="bg-primary text-primary-foreground border-4 border-foreground p-6 text-center">
-            <span className="font-[Bangers] text-4xl tracking-widest text-primary-foreground">
+            <span className="font-[Bangers] text-3xl sm:text-4xl tracking-widest text-primary-foreground">
               POW UI
             </span>
           </div>
@@ -529,7 +529,7 @@ function DisplacementDemo() {
           </span>
           <Filters.Displacement scale={scale[0]} frequency={freq[0]}>
             <div className="bg-primary text-primary-foreground border-4 border-foreground p-6 text-center">
-              <span className="font-[Bangers] text-4xl tracking-widest text-primary-foreground">
+              <span className="font-[Bangers] text-3xl sm:text-4xl tracking-widest text-primary-foreground">
                 POW UI
               </span>
             </div>
@@ -575,13 +575,13 @@ function ChromaAberrDemo() {
 
   return (
     <div className="flex flex-col gap-6 w-full">
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="flex flex-col gap-2">
           <span className="font-[Bangers] text-lg tracking-wide text-center">
             Original
           </span>
           <div className="bg-card text-card-foreground border-4 border-foreground p-6 text-center">
-            <span className="font-[Bangers] text-4xl tracking-widest">
+            <span className="font-[Bangers] text-3xl sm:text-4xl tracking-widest">
               POW UI
             </span>
           </div>
@@ -592,7 +592,7 @@ function ChromaAberrDemo() {
           </span>
           <Filters.ChromaAberr offset={offset[0]}>
             <div className="bg-card text-card-foreground border-4 border-foreground p-6 text-center">
-              <span className="font-[Bangers] text-4xl tracking-widest">
+              <span className="font-[Bangers] text-3xl sm:text-4xl tracking-widest">
                 POW UI
               </span>
             </div>
@@ -624,13 +624,13 @@ function PosterizeDemo() {
 
   return (
     <div className="flex flex-col gap-6 w-full">
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="flex flex-col gap-2">
           <span className="font-[Bangers] text-lg tracking-wide text-center">
             Original
           </span>
           <div className="bg-gradient-to-br from-amber-400 to-red-500 border-4 border-foreground p-6 text-center">
-            <span className="font-[Bangers] text-4xl tracking-widest text-white">
+            <span className="font-[Bangers] text-3xl sm:text-4xl tracking-widest text-white">
               POW UI
             </span>
           </div>
@@ -641,7 +641,7 @@ function PosterizeDemo() {
           </span>
           <Filters.Posterize buckets={buckets[0]}>
             <div className="bg-gradient-to-br from-amber-400 to-red-500 border-4 border-foreground p-6 text-center">
-              <span className="font-[Bangers] text-4xl tracking-widest text-white">
+              <span className="font-[Bangers] text-3xl sm:text-4xl tracking-widest text-white">
                 POW UI
               </span>
             </div>
@@ -850,7 +850,7 @@ function SkeletonDemo() {
   const [loading, setLoading] = useState(true);
 
   return (
-    <div className="flex flex-col gap-4 w-4xl">
+    <div className="flex flex-col gap-4 w-full max-w-4xl">
       <div className="flex items-center justify-between mb-2">
         <h4 className="font-[Bangers] text-xl tracking-wide">Loading State</h4>
         <Button
@@ -978,7 +978,7 @@ function HatchedBgDemo() {
       <div>
         <h4 className="font-[Bangers] text-xl tracking-wide mb-3">Angles</h4>
         <div className="flex items-center justify-center size-full">
-          <div className="grid grid-cols-4 grid-rows-2 gap-2 p-1 w-fit">
+          <div className="grid grid-cols-3 grid-rows-3 sm:grid-cols-4 sm:grid-rows-2 gap-2 p-1 w-fit">
             {angles.map((a) => (
               <div key={a} className="flex flex-col items-center gap-1 p-1">
                 <div

--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -37,29 +37,29 @@ function DemoPanel({ demo }: { demo: ComponentDemo }) {
       {/* Header */}
       <div
         className="bg-accent text-primary-foreground
-                      px-8 pt-8 pb-6 border-b-4 border-foreground"
+                      px-4 pt-6 pb-4 md:px-8 md:pt-8 md:pb-6 border-b-4 border-foreground"
       >
         <Filters.Displacement scale={1.5} frequency={0.05}>
-          <h1 className="font-[Bangers] text-5xl tracking-widest">
+          <h1 className="font-[Bangers] text-3xl md:text-5xl tracking-widest">
             {demo.label}
           </h1>
         </Filters.Displacement>
-        <p className="mt-2 font-medium text-primary-foreground/70 text-lg max-w-2xl">
+        <p className="mt-2 font-medium text-primary-foreground/70 text-base md:text-lg max-w-2xl">
           {demo.description}
         </p>
       </div>
 
       {/* Demo Area */}
-      <div className="flex-1 min-h-fit p-8 flex flex-col gap-8">
-        <div className="hatched-bg-primary hatched-opacity-20 text-primary-foreground border-4 border-foreground p-8 md:p-12 flex items-start justify-center min-h-fit">
+      <div className="flex-1 min-h-fit p-4 gap-6 md:p-8 md:gap-8 flex flex-col">
+        <div className="hatched-bg-primary hatched-opacity-20 text-primary-foreground border-4 border-foreground p-4 md:p-12 flex items-start justify-center min-h-fit">
           <Filters.Displacement
             scale={1.5}
             frequency={0.05}
             containerClassName="w-full flex items-center justify-center"
           >
             <div
-              className="bg-card text-card-foreground border-4 border-foreground shadow-[-8px_8px_0_0_var(--foreground)]
-                         p-8 w-fit"
+              className="bg-card text-card-foreground border-4 border-foreground shadow-[-4px_4px_0_0_var(--foreground)] md:shadow-[-8px_8px_0_0_var(--foreground)]
+                         p-4 md:p-8 w-fit max-w-full"
             >
               {demo.demo}
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,21 +28,21 @@ export default function Home() {
   return (
     <div className="relative min-h-screen selection:bg-amber-300 dark:selection:bg-amber-700">
       {/* ── Hero ────────────────────────────────────────────────────────── */}
-      <section className="flex flex-col items-center px-6 gap-8">
+      <section className="flex flex-col items-center px-4 sm:px-6 gap-4 sm:gap-8">
         <Filters.Displacement scale={3} frequency={2}>
-          <Button className="bg-card text-foreground dark:text-white w-80 h-32 text-7xl m-32">
+          <Button className="bg-card text-foreground dark:text-white w-48 h-20 text-4xl m-8 sm:w-64 sm:h-24 sm:text-5xl sm:m-16 md:w-80 md:h-32 md:text-7xl md:m-32">
             Pow UI
           </Button>
         </Filters.Displacement>
 
-        <div className="mx-auto max-w-2xl bg-card border-4 border-foreground shadow-[-8px_8px_0_0_var(--foreground)] overflow-hidden">
+        <div className="mx-auto max-w-2xl bg-card border-4 border-foreground shadow-[-4px_4px_0_0_var(--foreground)] md:shadow-[-8px_8px_0_0_var(--foreground)] overflow-hidden">
           <div className="spotty-dot-sm spotty-spacing-sm spotty-opacity-25 spotty-bg-accent px-6 py-2 border-b-4 border-foreground">
             <span className="font-[Bangers] text-sm tracking-[0.3em] uppercase">
               The Comic UI Library
             </span>
           </div>
           <div className="p-6">
-            <div className="text-2xl md:text-3xl font-bold leading-tight">
+            <div className="text-xl sm:text-2xl md:text-3xl font-bold leading-tight">
               A punchy, comic-inspired UI library for interfaces that{" "}
               <SpiderSenseWrapper containerClassName="inline" trigger="hover">
                 <span className="text-orange-400 dark:text-orange-300 underline decoration-foreground underline-offset-4">
@@ -65,22 +65,22 @@ export default function Home() {
         <div className="grid grid-cols-1 md:grid-cols-2">
           {[
             {
-              icon: <TailwindIcon className="size-8" />,
+              icon: <TailwindIcon className="size-6 md:size-8" />,
               title: "Made with Tailwind",
               text: "Utility-first styling with no custom CSS to fight. Every style is a class — compose, override, and ship without leaving your markup.",
             },
             {
-              icon: <Code2 className="size-8" />,
+              icon: <Code2 className="size-6 md:size-8" />,
               title: "Open Source",
               text: "MIT licensed. Free forever. Fork it, own it, and build something worth shouting about. No paywalls, no lock-in.",
             },
             {
-              icon: <Layers className="size-8" />,
+              icon: <Layers className="size-6 md:size-8" />,
               title: "Based on shadcn",
               text: "Built on shadcn/ui primitives. Familiar copy-paste setup, zero runtime overhead, comic-book personality baked in.",
             },
             {
-              icon: <SlidersHorizontal className="size-8" />,
+              icon: <SlidersHorizontal className="size-6 md:size-8" />,
               title: "Fully Customizable",
               text: "Every component is a starting point, not an endpoint. Override anything with Tailwind classes — no specificity fights.",
             },
@@ -88,7 +88,7 @@ export default function Home() {
             <div
               key={i}
               className={[
-                "p-10 flex flex-col gap-5 border-foreground",
+                "p-6 md:p-10 flex flex-col gap-5 border-foreground",
                 i % 2 === 0 ? "md:border-r-4" : "",
                 i < 2
                   ? "border-b-4"
@@ -98,10 +98,10 @@ export default function Home() {
               ].join(" ")}
             >
               <div className="flex items-center gap-4">
-                <div className="size-16 bg-card text-foreground border-4 border-foreground flex items-center justify-center shrink-0">
+                <div className="size-12 md:size-16 bg-card text-foreground border-4 border-foreground flex items-center justify-center shrink-0">
                   {item.icon}
                 </div>
-                <h3 className="font-[Bangers] text-3xl tracking-wider">
+                <h3 className="font-[Bangers] text-2xl md:text-3xl tracking-wider">
                   {item.title}
                 </h3>
               </div>
@@ -116,20 +116,20 @@ export default function Home() {
       {/* ── CTA Banner ──────────────────────────────────────────────────── */}
       <section
         className="spotty-dot-sm spotty-spacing-sm spotty-opacity-20 spotty-bg-primary text-primary-foreground
-                   border-y-4 border-foreground py-16 px-6 flex flex-col items-center gap-8"
+                   border-y-4 border-foreground py-10 px-4 sm:py-16 sm:px-6 flex flex-col items-center gap-8"
       >
         <Filters.Displacement scale={2} frequency={0.06}>
-          <h2 className="font-[Bangers] text-6xl md:text-8xl text-primary-foreground text-center tracking-widest">
+          <h2 className="font-[Bangers] text-4xl sm:text-6xl md:text-8xl text-primary-foreground text-center tracking-widest">
             READY TO BUILD?
           </h2>
         </Filters.Displacement>
-        <p className="text-primary-foreground/70 text-xl text-center max-w-xl font-medium">
+        <p className="text-primary-foreground/70 text-base sm:text-xl text-center max-w-xl font-medium">
           Explore all 18 components — buttons, shapes, filters, animations,
           toasts, sidebars, and more.
         </p>
         <Button
           size="lg"
-          className="text-2xl px-10 h-16 font-[Bangers] tracking-widest bg-accent text-accent-foreground hover:bg-accent"
+          className="text-lg px-6 h-12 sm:text-2xl sm:px-10 sm:h-16 font-[Bangers] tracking-widest bg-accent text-accent-foreground hover:bg-accent"
           asChild
         >
           <Link href="/components">Browse All Components →</Link>
@@ -139,27 +139,27 @@ export default function Home() {
       {/* ── Footer ──────────────────────────────────────────────────────── */}
       <footer
         className="spotty-dot-sm spotty-spacing-sm spotty-opacity-20 spotty-bg-primary text-primary-foreground
-                   border-t-4 border-foreground px-8 pt-16 pb-20 relative"
+                   border-t-4 border-foreground px-4 sm:px-8 pt-10 sm:pt-16 pb-24 sm:pb-20 relative"
       >
-        <div className="max-w-5xl mx-auto flex flex-col md:flex-row justify-between items-start gap-12">
+        <div className="max-w-5xl mx-auto flex flex-col md:flex-row justify-between items-center md:items-start gap-8 md:gap-12">
           <div className="flex flex-col gap-4">
-            <Filters.Displacement scale={2} frequency={0.06}>
-              <Button className="px-6 py-8 font-[Bangers] text-5xl tracking-widest text-foreground bg-card dark:text-white">
+            <Filters.Displacement scale={4} frequency={0.06}>
+              <Button className="px-4 py-6 text-3xl sm:px-6 sm:py-8 sm:text-5xl font-[Bangers] tracking-widest text-foreground bg-card dark:text-white">
                 POW UI
               </Button>
             </Filters.Displacement>
-            <p className="text-lg font-medium text-primary-foreground max-w-xs">
+            <p className="text-base sm:text-lg font-medium text-primary-foreground max-w-xs">
               Making the web more exciting,
               <br />
               one punch at a time.
             </p>
           </div>
-          <div className="flex flex-col items-end gap-3">
+          <div className="flex flex-col items-start md:items-end gap-3">
             <a
               href=""
               target="_blank"
               rel="noopener noreferrer"
-              className="font-[Bangers] text-2xl tracking-wide border-b-4 border-foreground hover:text-amber-700 dark:hover:text-amber-300 transition-colors no-underline w-fit"
+              className="font-[Bangers] text-xl sm:text-2xl tracking-wide border-b-4 border-foreground hover:text-amber-700 dark:hover:text-amber-300 transition-colors no-underline w-fit"
             >
               <svg
                 className="size-5 inline-block"
@@ -175,13 +175,13 @@ export default function Home() {
               href="https://www.chromatic.com/library?appId=68b33f12384a75f2c732fa44"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-[Bangers] text-2xl tracking-wide border-b-4 border-foreground hover:text-amber-700 dark:hover:text-amber-300 transition-colors no-underline"
+              className="font-[Bangers] text-xl sm:text-2xl tracking-wide border-b-4 border-foreground hover:text-amber-700 dark:hover:text-amber-300 transition-colors no-underline"
             >
               Storybook
             </a>
           </div>
         </div>
-        <div className="absolute bottom-0 left-0 right-0 border-t-4 border-foreground bg-accent text-accent-foreground px-8 py-4">
+        <div className="absolute bottom-0 left-0 right-0 border-t-4 border-foreground bg-accent text-accent-foreground px-4 py-3 sm:px-8 sm:py-4">
           <p className="text-accent-foreground/70 text-sm font-medium text-center">
             Built with React, Next.js, Tailwind CSS, and a whole lot of comic
             energy.

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Github, Moon, Sun } from "lucide-react";
+import { Github, LayoutGrid, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { HoverWrap } from "./website/Hoverwrap";
 import { Button } from "./ui/button";
@@ -40,40 +40,43 @@ export function NavBar() {
   const path = usePathname();
   const isComponentsPage = path.startsWith("/components");
   return (
-    <nav className="sticky top-0 left-0 right-0 z-50 h-18 border-b-4 border-foreground spotty-dot-sm spotty-spacing-sm spotty-opacity-30 spotty-bg-accent flex-shrink-0 flex items-center justify-between pr-6">
-      <div className="bg-black px-8 justify-center flex items-center h-full">
+    <nav className="sticky top-0 left-0 right-0 z-50 h-14 sm:h-18 border-b-4 border-foreground spotty-dot-sm spotty-spacing-sm spotty-opacity-30 spotty-bg-accent flex-shrink-0 flex items-center justify-between pr-3 sm:pr-6">
+      <div className="bg-black px-4 sm:px-8 justify-center flex items-center h-full">
         <HoverWrap withAnimation>
           <Link
             href="/"
-            className="font-[Bangers] text-5xl text-white! no-underline hover:opacity-80 transition-opacity"
+            className="font-[Bangers] text-3xl sm:text-5xl text-white! no-underline hover:opacity-80 transition-opacity"
           >
             POW UI
           </Link>
         </HoverWrap>
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 sm:gap-3">
         {!isComponentsPage && (
           <HoverWrap>
-            <div className="border-3 border-foreground bg-card text-foreground px-4 py-1.5 shadow-[-6px_6px_0_var(--foreground)] flex items-center h-9">
+            <div className="border-3 border-foreground bg-card text-foreground px-2.5 sm:px-4 py-1.5 shadow-[-6px_6px_0_var(--foreground)] flex items-center h-9">
               <Link
                 href="/components"
-                className="font-bold text-sm text-foreground no-underline"
+                aria-label="Components"
+                className="font-bold text-sm text-foreground no-underline flex items-center"
               >
-                Components
+                <LayoutGrid className="size-4 sm:hidden" />
+                <span className="hidden sm:inline">Components</span>
               </Link>
             </div>
           </HoverWrap>
         )}
         <HoverWrap>
-          <div className="border-3 border-foreground bg-card text-foreground px-4 py-1.5 shadow-[-6px_6px_0_var(--foreground)] flex items-center h-9">
+          <div className="border-3 border-foreground bg-card text-foreground px-2.5 sm:px-4 py-1.5 shadow-[-6px_6px_0_var(--foreground)] flex items-center h-9">
             <a
               href="https://github.com/sid0-0/powui"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-bold text-sm text-foreground no-underline flex items-center gap-1.5"
+              aria-label="GitHub"
+              className="font-bold text-sm text-foreground no-underline flex items-center gap-0 sm:gap-1.5"
             >
               <Github className="size-4" />
-              GitHub ↗
+              <span className="hidden sm:inline">GitHub ↗</span>
             </a>
           </div>
         </HoverWrap>


### PR DESCRIPTION
## Summary

- **NavBar**: icon-only pills below `sm` (640px) — `LayoutGrid` icon for Components, `Github` icon for GitHub; logo scales `text-3xl → sm:text-5xl`; nav height `h-14 → sm:h-18`
- **Landing page (`/`)**: hero button, card shadow, copy, feature icons/cards, CTA banner, and footer all get responsive size steps at `sm`/`md`; footer centers on mobile and aligns end at `md`
- **Components page (`/components`)**: `DemoPanel` header padding, heading size, and demo frame padding slimmed with `md:` variants
- **Demos (`demos.tsx`)**: comparison grids (`Displacement`, `ChromaAberr`, `Posterize`) stack to 1-col below `sm`; `SkeletonDemo` drops fixed `w-4xl` → `w-full max-w-4xl`; `CloudDemo` shrinks at mobile; `HatchedBgDemo` angles grid reshapes 3×3 → `sm:4×2`
- **InstallCommands**: tab row and copy-button gap collapse at mobile; `Tabs` + `TabsList` go full-width so all 4 package-manager tabs are reachable at 360px

No desktop layout changes. `pnpm next build` passes clean.

## Test plan

- [ ] Open `/` at 360px — no horizontal scroll; hero, CTA, footer fit
- [ ] NavBar at 360px — icon-only pills; at 640px — text labels reappear
- [ ] Open `/components` at 360px — sidebar trigger visible, demo panel header fits
- [ ] Step through Displacement / ChromaAberr / Posterize demos at 360px — panels stack vertically
- [ ] Skeleton demo at 360px — rows fill width
- [ ] InstallCommands at 360px — all 4 tabs (PNPM/NPM/YARN/BUN) visible and selectable
- [ ] Resize 360px → 1280px — no layout pops

🤖 Generated with [Claude Code](https://claude.com/claude-code)